### PR TITLE
ci: update ci to use ctlptl to create a cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,13 @@ jobs:
       - image: tiltdev/tilt:latest
 
     steps:
-      - setup_remote_docker
       - checkout
+      - setup_remote_docker:
+          version: 19.03.12
       - run: apt install -y wget gpg
       - run: "wget -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
               mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
               wget https://packages.microsoft.com/config/debian/10/prod.list && \
               mv prod.list /etc/apt/sources.list.d/microsoft-prod.list"
       - run: apt update && apt install -y dotnet-sdk-3.1 python
-      - run: with-kind-cluster.sh test/test.sh
+      - run: ctlptl create cluster kind --registry=ctlptl-registry && test/test.sh


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ci:

9932bb3ef6e7af7fd00e96ccca81f83f363956e5 (2021-03-19 18:58:29 -0400)
ci: update ci to use ctlptl to create a cluster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics